### PR TITLE
🐛 [Fix] 로그인-온보딩 데이터 흐름 연결 및 애플 로그인 토큰 수정

### DIFF
--- a/MeetKey/MeetKey/Presentation/Login/LoginViewModel.swift
+++ b/MeetKey/MeetKey/Presentation/Login/LoginViewModel.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import Combine
 
 class LoginViewModel: ObservableObject {
+    private let isNewMemberKey = "isNewMember"
+    private let authProviderKey = "authProvider"
+    private let lastIdTokenKey = "lastIdToken"
     @Published var phoneNumber: String = ""
     @Published var verifyCode: String = ""
     
@@ -29,6 +32,10 @@ class LoginViewModel: ObservableObject {
                 let response = try await authService.login(provider: provider, idToken: idToken)
                 self.loginResponse = response
                 self.isLoginSuccess = true
+
+                UserDefaults.standard.set(response.isNewMember, forKey: isNewMemberKey)
+                UserDefaults.standard.set(provider.rawValue, forKey: authProviderKey)
+                UserDefaults.standard.set(idToken, forKey: lastIdTokenKey)
 
                 if response.isNewMember {
                     self.shouldNavigateToSignup = true


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
**[로그인 및 온보딩 프로세스 정상화]**
1. **403 Forbidden 에러 해결:**
   - OnboardingViewModel에서 신규 유저(isNewMember: true)일 경우, 데이터를 저장하기 전에 **회원가입(signup) API를 먼저 호출**하여 정식 토큰을 발급받도록 수정했습니다.
   - 필수값인 phoneNumber에 더미 데이터 적용

2. **데이터 전달 흐름 연결:**
   - LoginViewModel에서 로그인 성공 시 idToken, provider, isNewMember 정보를 UserDefaults에 임시 저장하여 온보딩 화면에서 사용할 수 있도록 했습니다.

3. **애플 로그인 수정:**
   - AppleSignInCoordinator에서 발생하던 컴파일 에러(.identityToken 프로퍼티 접근 문제)를 수정했습니다.

## 📋 추후 진행 상황
- phoneNumber 실제 입력 로직 구현 필요

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [ ] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
